### PR TITLE
fix RustHoverRange

### DIFF
--- a/lua/rust-tools/hover_range.lua
+++ b/lua/rust-tools/hover_range.lua
@@ -1,29 +1,52 @@
-local utils = require("rust-tools.utils.utils")
-
 local M = {}
+
+-- Converts a tuple of range coordinates into LSP's position argument
+local function make_lsp_position(row1, col1, row2, col2)
+  -- Note: vim's lines are 1-indexed, but LSP's are 0-indexed
+  return {
+    ["start"] = {
+      line = row1 - 1,
+      character = col1,
+    },
+    ["end"] = {
+      line = row2 - 1,
+      character = col2,
+    },
+  }
+end
+
+local function get_visual_selected_range()
+  -- Taken from https://github.com/neovim/neovim/pull/13896#issuecomment-774680224
+  local p1 = vim.fn.getpos("v")
+  local row1 = p1[2]
+  local col1 = p1[3]
+  local p2 = vim.api.nvim_win_get_cursor(0)
+  local row2 = p2[1]
+  local col2 = p2[2]
+
+  if row1 < row2 then
+    return make_lsp_position(row1, col1, row2, col2)
+  elseif row2 < row1 then
+    return make_lsp_position(row2, col2, row1, col1)
+  end
+
+  return make_lsp_position(
+    row1,
+    math.min(col1, col2),
+    row1,
+    math.max(col1, col2)
+  )
+end
 
 local function get_opts()
   local params = vim.lsp.util.make_range_params()
-  -- set start and end of selection
-  local start_m = vim.api.nvim_buf_get_mark(0, "<")
-  local end_m = vim.api.nvim_buf_get_mark(0, ">")
-  params.range.start = {
-    character = start_m[2],
-    line = start_m[1] - 1, -- vim starts counting at 1, but lsp at 0
-  }
-  params.range["end"] = {
-    character = end_m[2],
-    line = end_m[1] - 1, -- vim starts counting at 1, but lsp at 0
-  }
-  params.position = params.range
+  params.position = get_visual_selected_range()
   params.range = nil
-  --print(vim.inspect(params))
-
   return params
 end
 
 function M.hover_range()
-  utils.request(0, "textDocument/hover", get_opts())
+  vim.lsp.buf_request(0, "textDocument/hover", get_opts())
 end
 
 return M


### PR DESCRIPTION
RustHoverRange was broken in two places:
1) utils.request() was missing an argument, so it used to throw an
   error.
2) RustHoverRange used the range of the _previous_ visual selection, not
   the current one.